### PR TITLE
Simplify filesystem module duktape registration

### DIFF
--- a/src/filesystem_bindings.c
+++ b/src/filesystem_bindings.c
@@ -254,3 +254,37 @@ duk_ret_t duk_list_dirs_count(duk_context *ctx) {
     duk_push_int(ctx, count);
     return 1;
 }
+
+// Table for FS module using Duktape's duk_function_list_entry
+static const duk_function_list_entry fs_function_list[] = {
+    { "readFile", duk_read_file, 1 },
+    { "readTextFile", duk_read_text_file, 1 },
+    { "writeFile", duk_write_file, 2 },
+    { "writeTextFile", duk_write_text_file, 2 },
+    { "appendTextFile", duk_append_text_file, 2 },
+    { "removeFile", duk_remove_file, 1 },
+    { "renameFile", duk_rename_file, 2 },
+    { "mkdir", duk_mkdir, 1 },
+    { "rmdir", duk_rmdir, 1 },
+    { "fileExists", duk_file_exists, 1 },
+    { "fileSize", duk_file_size, 1 },
+    { "moveFile", duk_move_file, 2 },
+    { "isDir", duk_is_dir, 1 },
+    { "isFile", duk_is_file, 1 },
+    { "touchFile", duk_touch_file, 1 },
+    { "getModTime", duk_get_mod_time, 1 },
+    { "listFiles", duk_list_files, 1 },
+    { "listDirs", duk_list_dirs, 1 },
+    { "listFilesCount", duk_list_files_count, 1 },
+    { "listDirsCount", duk_list_dirs_count, 1 },
+    { "copyFile", duk_copy_file, DUK_VARARGS },
+    { "copyDirFiles", duk_copy_dir_files, DUK_VARARGS },
+    { "copyDirFilesPattern", duk_copy_dir_files_pattern, DUK_VARARGS },
+    { NULL, NULL, 0 }
+};
+
+void register_filesystem_module(duk_context *ctx) {
+    duk_push_object(ctx);
+    duk_put_function_list(ctx, -1, fs_function_list);
+    duk_put_global_string(ctx, "FS");
+}

--- a/src/filesystem_bindings.h
+++ b/src/filesystem_bindings.h
@@ -1,38 +1,11 @@
 #ifndef FILESYSTEM_BINDINGS_H
 #define FILESYSTEM_BINDINGS_H
-
+#include "duktape.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "duktape.h"
-
-duk_ret_t duk_append_text_file(duk_context *ctx);
-duk_ret_t duk_rename_file(duk_context *ctx);
-duk_ret_t duk_file_exists(duk_context *ctx);
-duk_ret_t duk_copy_file(duk_context *ctx);
-duk_ret_t duk_copy_dir_files(duk_context *ctx);
-duk_ret_t duk_read_file(duk_context *ctx);
-duk_ret_t duk_read_text_file(duk_context *ctx);
-duk_ret_t duk_write_file(duk_context *ctx);
-duk_ret_t duk_write_text_file(duk_context *ctx);
-duk_ret_t duk_remove_file(duk_context *ctx);
-duk_ret_t duk_mkdir(duk_context *ctx);
-duk_ret_t duk_rmdir(duk_context *ctx);
-duk_ret_t duk_file_size(duk_context *ctx);
-duk_ret_t duk_move_file(duk_context *ctx);
-duk_ret_t duk_is_dir(duk_context *ctx);
-duk_ret_t duk_is_file(duk_context *ctx);
-duk_ret_t duk_touch_file(duk_context *ctx);
-duk_ret_t duk_get_mod_time(duk_context *ctx);
-duk_ret_t duk_list_files(duk_context *ctx);
-duk_ret_t duk_list_dirs(duk_context *ctx);
-duk_ret_t duk_copy_dir_files_pattern(duk_context *ctx);
-duk_ret_t duk_list_files_count(duk_context *ctx);
-duk_ret_t duk_list_dirs_count(duk_context *ctx);
-
+void register_filesystem_module(duk_context *ctx);
 #ifdef __cplusplus
 }
 #endif
-
 #endif // FILESYSTEM_BINDINGS_H

--- a/src/js2000_bindings.c
+++ b/src/js2000_bindings.c
@@ -109,39 +109,9 @@ static duk_ret_t duk_print_to_screen(duk_context *ctx) {
     return 0;
 }
 
-// Table for FS module using Duktape's duk_function_list_entry
-static const duk_function_list_entry fs_function_list[] = {
-    { "readFile", duk_read_file, 1 },
-    { "readTextFile", duk_read_text_file, 1 },
-    { "writeFile", duk_write_file, 2 },
-    { "writeTextFile", duk_write_text_file, 2 },
-    { "appendTextFile", duk_append_text_file, 2 },
-    { "removeFile", duk_remove_file, 1 },
-    { "renameFile", duk_rename_file, 2 },
-    { "mkdir", duk_mkdir, 1 },
-    { "rmdir", duk_rmdir, 1 },
-    { "fileExists", duk_file_exists, 1 },
-    { "fileSize", duk_file_size, 1 },
-    { "moveFile", duk_move_file, 2 },
-    { "isDir", duk_is_dir, 1 },
-    { "isFile", duk_is_file, 1 },
-    { "touchFile", duk_touch_file, 1 },
-    { "getModTime", duk_get_mod_time, 1 },
-    { "listFiles", duk_list_files, 1 },
-    { "listDirs", duk_list_dirs, 1 },
-    { "listFilesCount", duk_list_files_count, 1 },
-    { "listDirsCount", duk_list_dirs_count, 1 },
-    { "copyFile", duk_copy_file, DUK_VARARGS },
-    { "copyDirFiles", duk_copy_dir_files, DUK_VARARGS },
-    { "copyDirFilesPattern", duk_copy_dir_files_pattern, DUK_VARARGS },
-    { NULL, NULL, 0 }
-};
-
 void js2000_register_bindings(duk_context *ctx) {
     // Register FS module
-    duk_push_object(ctx); // -> [ FS ]
-    duk_put_function_list(ctx, -1, fs_function_list);
-    duk_put_global_string(ctx, "FS"); // global.FS = { ... }
+    register_filesystem_module(ctx);
 
     // Register console.log(msg) as a global JS function
     duk_push_object(ctx);


### PR DESCRIPTION
This pull request refactors the filesystem module bindings in the project to improve modularity and maintainability. The changes include consolidating the filesystem binding registration into a dedicated function, removing redundant code, and simplifying the header file. 

### Filesystem module refactor:

* [`src/filesystem_bindings.c`] Added a new function, `register_filesystem_module`, to encapsulate the registration of filesystem bindings using a `duk_function_list_entry` table. This improves modularity and centralizes the registration logic.
* [`src/filesystem_bindings.h`] Simplified the header file by removing individual function declarations for filesystem operations and replacing them with a single declaration for `register_filesystem_module`.

### Code cleanup:

* [`src/js2000_bindings.c`] Removed the inline `fs_function_list` table and replaced its usage with the new `register_filesystem_module` function. This reduces redundancy and improves code readability.